### PR TITLE
#5 replace original configuration with new one before pre check

### DIFF
--- a/confd/service/command.go
+++ b/confd/service/command.go
@@ -1,13 +1,12 @@
 package service
 
 import (
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
-	"path/filepath"
 
-	"github.com/pkg/errors"
+  "github.com/pkg/errors"
+  "github.com/satori/go.uuid"
 )
 
 func executeCommand(command string) error {
@@ -30,30 +29,82 @@ func post(command string) error {
 }
 
 func preCheck(conf Configuration, data interface{}) error {
-	dir := filepath.Dir(conf.Target)
-	prefix := filepath.Base(conf.Target)
-	tmpFile, err := ioutil.TempFile(dir, prefix)
-	if err != nil {
-		return errors.Wrap(err, "failed to create temp file for pre check")
-	}
+  _, statErr := os.Stat(conf.Target)
+  if statErr == nil {
+    err := executePreCheckWithExistingConfiguration(conf, data)
+    if err != nil {
+      return errors.Wrap(err, "failed to execute pre check with existing configuration")
+    }
 
-	defer func() {
-		err := os.Remove(tmpFile.Name())
-		if err != nil {
-			// TODO check if this is a fatal case
-			log.Printf("failed to remove temporary file: %v", err)
-		}
-	}()
+    return nil
+  } else if !os.IsNotExist(statErr) {
+    return errors.Wrapf(statErr, "failed to stat file %s", conf.Target)
+  }
 
-	conf.Target = tmpFile.Name()
-	err = write(conf, data)
-	if err != nil {
-		return errors.Wrap(err, "failed to write to temp file for pre check")
-	}
-	log.Println("execute pre command", conf.PreCommand)
-	err = executeCommand(conf.PreCommand)
-	if err != nil {
-		return errors.Wrap(err, "pre check command failed")
-	}
-	return err
+  err := executePreCheckWithNewConfiguration(conf, data)
+  if err != nil {
+    return errors.Wrap(err, "failed to execute pre check with new configuration")
+  }
+
+  return nil
+}
+
+func executePreCheckWithExistingConfiguration(conf Configuration, data interface{}) error {
+  tmpPath := createTempPath(conf)
+
+  log.Printf("move configuration %s to tempoarary location %s for pre check", conf.Target, tmpPath)
+
+  err := os.Rename(conf.Target, tmpPath)
+  if err != nil {
+    return errors.Wrapf(err, "failed to rename %s to temp file %s", conf.Target, tmpPath)
+  }
+
+  defer func(){
+    log.Printf("move temporary configuration %s back to original location %s", tmpPath, conf.Target)
+    err := os.Rename(tmpPath, conf.Target)
+    if err != nil {
+      log.Printf("failed to rename temporary configuration %s back to original location %s: %v", tmpPath, conf.Target, err)
+    }
+  }()
+
+  err = executePreCheck(conf, data)
+  if err != nil {
+    return err
+  }
+
+  return nil
+}
+
+func createTempPath(conf Configuration) string {
+  return conf.Target + ".ces-confd-" + uuid.NewV4().String()
+}
+
+func executePreCheckWithNewConfiguration(conf Configuration, data interface{}) error {
+  defer func(){
+    err := os.Remove(conf.Target)
+    if err != nil {
+      log.Println("failed to remove temporary configuration", conf.Target)
+    }
+  }()
+
+  err := executePreCheck(conf, data)
+  if err != nil {
+    return err
+  }
+
+  return nil
+}
+
+func executePreCheck(conf Configuration, data interface{}) error {
+  err := write(conf, data)
+  if err != nil {
+    return errors.Wrap(err, "failed to write to temp file for pre check")
+  }
+
+  log.Println("execute pre command", conf.PreCommand)
+  err = executeCommand(conf.PreCommand)
+  if err != nil {
+    return errors.Wrap(err, "pre check command failed")
+  }
+  return err
 }

--- a/confd/service/command_test.go
+++ b/confd/service/command_test.go
@@ -1,0 +1,107 @@
+package service
+
+import (
+  "testing"
+  "io/ioutil"
+  "os"
+  "path"
+  "github.com/stretchr/testify/require"
+)
+
+func TestPreCheck(t *testing.T) {
+  directory, err := ioutil.TempDir("", "")
+  require.Nil(t, err)
+  defer func() {
+    os.RemoveAll(directory)
+  }()
+
+  template := path.Join(directory, "template")
+  err = ioutil.WriteFile(template, []byte("{{.Name}}"), 0644)
+  require.Nil(t, err)
+
+  target := path.Join(directory, "target")
+  err = ioutil.WriteFile(target, []byte("trillian"), 0644)
+  require.Nil(t, err)
+
+  conf := Configuration{
+    Target: target,
+    Template: template,
+    PreCommand: "grep slarti " + target,
+  }
+
+  err = preCheck(conf, model{"slarti"})
+  require.Nil(t, err)
+
+  // be sure old file gets restored
+  _, err = os.Stat(target)
+  require.Nil(t, err)
+
+  content, err := ioutil.ReadFile(target)
+  require.Nil(t, err)
+
+  require.Equal(t, "trillian", string(content))
+}
+
+func TestPreCheckFailed(t *testing.T) {
+  directory, err := ioutil.TempDir("", "")
+  require.Nil(t, err)
+  defer func() {
+    os.RemoveAll(directory)
+  }()
+
+  template := path.Join(directory, "template")
+  err = ioutil.WriteFile(template, []byte("{{.Name}}"), 0644)
+  require.Nil(t, err)
+
+  target := path.Join(directory, "target")
+  err = ioutil.WriteFile(target, []byte("trillian"), 0644)
+  require.Nil(t, err)
+
+  // grep trillian should fail, because the pre check writes slarti to the target
+
+  conf := Configuration{
+    Target: target,
+    Template: template,
+    PreCommand: "grep trillian " + target,
+  }
+
+  err = preCheck(conf, model{"slarti"})
+  require.NotNil(t, err)
+
+  // be sure old file gets restored
+  content, err := ioutil.ReadFile(target)
+  require.Nil(t, err)
+
+  require.Equal(t, "trillian", string(content))
+}
+
+func TestPreCheckWithoutExistingConfiguration(t *testing.T) {
+  directory, err := ioutil.TempDir("", "")
+  require.Nil(t, err)
+  defer func() {
+    os.RemoveAll(directory)
+  }()
+
+  template := path.Join(directory, "template")
+  err = ioutil.WriteFile(template, []byte("{{.Name}}"), 0644)
+  require.Nil(t, err)
+
+  target := path.Join(directory, "target")
+
+  conf := Configuration{
+    Target: target,
+    Template: template,
+    PreCommand: "grep trillian " + target,
+  }
+
+  err = preCheck(conf, model{"slarti"})
+  require.NotNil(t, err)
+
+  // be sure target does not exists
+  _, err = os.Stat(target)
+  require.True(t, os.IsNotExist(err))
+}
+
+type model struct {
+  Name string
+}

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 23cab2cfed9c5849a602534d350dbe8a6be155d17b02785b8c671e6e9799a5fc
-updated: 2016-07-19T15:49:11.854888574+02:00
+hash: 787ed6780f2a8dfc507b6e1128636a4ff56a9d572ef5bc3f6b182dfd0e16b70b
+updated: 2018-01-04T11:14:33.596088046+01:00
 imports:
 - name: github.com/codegangsta/cli
   version: 11c134509d89c2018675f369955218a180dc7428
@@ -12,6 +12,8 @@ imports:
   - pkg/types
 - name: github.com/pkg/errors
   version: cc5fbb72d9b1b5f664ff3c11ed7896ee23ad9276
+- name: github.com/satori/go.uuid
+  version: 879c5887cd475cd7864858769793b2ceb0d44feb
 - name: github.com/ugorji/go
   version: b94837a2404ab90efe9289e77a70694c355739cb
   subpackages:
@@ -22,4 +24,17 @@ imports:
   - context
 - name: gopkg.in/yaml.v2
   version: e4d366fc3c7938e2958e662b4258c7a89e1f0e3e
-devImports: []
+testImports:
+- name: github.com/davecgh/go-spew
+  version: 04cdfd42973bb9c8589fd6a731800cf222fde1a9
+  subpackages:
+  - spew
+- name: github.com/pmezard/go-difflib
+  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
+  subpackages:
+  - difflib
+- name: github.com/stretchr/testify
+  version: b91bfb9ebec76498946beb6af7c0230c7cc7ba6c
+  subpackages:
+  - assert
+  - require

--- a/glide.yaml
+++ b/glide.yaml
@@ -10,3 +10,11 @@ import:
   subpackages:
   - context
 - package: github.com/pkg/errors
+- package: github.com/satori/go.uuid
+  version: v1.1.0
+testImport:
+- package: github.com/stretchr/testify
+  version: v1.2.0
+  subpackages:
+  - assert
+  - require


### PR DESCRIPTION
old wrong behaviour:
ces-confd writes a the new configuration to a temp file and tests the
old configuration with the pre check command. The new configuration is
never tested, before service reload.

new behaviour:
The original configuration file gets moved to a temporary location and
the new configuration is written to the original location, before the
pre check command is executed. After the pre check the original state
gets restored regardless of the pre check command result.